### PR TITLE
docs: v4.3.2 release notes — amd64 PG16 bg_mon startup fix

### DIFF
--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -7,17 +7,17 @@ i18n:
 
 # Release Notes
 
-## v4.3.2
+## v4.3.3
 
 ### Fixed Issues
 
-- **PostgreSQL 16 clusters failed to start on amd64 nodes.** The Spilo image shipped with v4.3.1 contained a `bg_mon` extension compiled against the wrong PostgreSQL major version on the amd64 architecture, causing PostgreSQL 16 instances to fail at startup with `could not load library ".../16/lib/bg_mon.so": undefined symbol: pgstat_fetch_stat_beentry`. The extension build now pins the target PostgreSQL version explicitly, and the fixed image has been verified across all supported PostgreSQL versions on both amd64 and arm64. arm64 clusters and other PostgreSQL versions were not affected. Affected v4.3.1 clusters recover by upgrading the plugin to v4.3.2.
+- **PostgreSQL 16 clusters failed to start on amd64 nodes.** The Spilo image shipped with v4.3.1 contained a `bg_mon` extension compiled against the wrong PostgreSQL major version on the amd64 architecture, causing PostgreSQL 16 instances to fail at startup with `could not load library ".../16/lib/bg_mon.so": undefined symbol: pgstat_fetch_stat_beentry`. The extension build now pins the target PostgreSQL version explicitly, and the fixed image has been verified across all supported PostgreSQL versions on both amd64 and arm64. arm64 clusters and other PostgreSQL versions were not affected. Affected v4.3.1 clusters recover by upgrading the plugin to v4.3.3.
 
-{/* release-notes-for-bugs?template=mw-pg-v4.3.2-fixed&project=Middleware */}
+{/* release-notes-for-bugs?template=mw-pg-v4.3.3-fixed&project=Middleware */}
 
 ### Known Issues
 
-{/* release-notes-for-bugs?template=mw-pg-v4.3.2-known&project=Middleware */}
+{/* release-notes-for-bugs?template=mw-pg-v4.3.3-known&project=Middleware */}
 
 ## v4.3.1
 

--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -7,6 +7,18 @@ i18n:
 
 # Release Notes
 
+## v4.3.2
+
+### Fixed Issues
+
+- **PostgreSQL 16 clusters failed to start on amd64 nodes.** The Spilo image shipped with v4.3.1 contained a `bg_mon` extension compiled against the wrong PostgreSQL major version on the amd64 architecture, causing PostgreSQL 16 instances to fail at startup with `could not load library ".../16/lib/bg_mon.so": undefined symbol: pgstat_fetch_stat_beentry`. The extension build now pins the target PostgreSQL version explicitly, and the fixed image has been verified across all supported PostgreSQL versions on both amd64 and arm64. arm64 clusters and other PostgreSQL versions were not affected. Affected v4.3.1 clusters recover by upgrading the plugin to v4.3.2.
+
+{/* release-notes-for-bugs?template=mw-pg-v4.3.2-fixed&project=Middleware */}
+
+### Known Issues
+
+{/* release-notes-for-bugs?template=mw-pg-v4.3.2-known&project=Middleware */}
+
 ## v4.3.1
 
 ### New and Optimized Features


### PR DESCRIPTION
Adds the v4.3.2 section to release notes.

v4.3.2 is a hotfix release for MIDDLEWARE-32461: the v4.3.1 Spilo image shipped a wrong-major `bg_mon.so` in the PostgreSQL 16 slot on amd64 only, so amd64 PG16 clusters could not start. v4.3.2 ships the corrected Spilo build (verified on all arch × PG-major combinations); no other changes vs v4.3.1.

The JIRA Feature field on MIDDLEWARE-32461 is set to "MiddleWare - PostgreSQL" so the `release-notes-for-bugs` block resolves (see the v4.3.0 empty-Fixed-Issues lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)